### PR TITLE
Add CSS classes for admin forms and messages

### DIFF
--- a/tareas/admin/templates/admin/configuraciones.html
+++ b/tareas/admin/templates/admin/configuraciones.html
@@ -10,7 +10,7 @@
 {% block contenido %}
 <div class="listado-card">
     <h2>Configuraciones Generales</h2>
-    <form method="post" class="form-grid" style="margin-bottom:20px;">
+    <form method="post" class="form-grid filter-form">
         {% csrf_token %}
         <div class="form-field">{{ form.nombre_clinica.label_tag }}{{ form.nombre_clinica }}</div>
         <div class="form-field">{{ form.logo_url.label_tag }}{{ form.logo_url }}</div>

--- a/tareas/admin/templates/admin/editar_paciente.html
+++ b/tareas/admin/templates/admin/editar_paciente.html
@@ -36,7 +36,7 @@
             <button type="submit" class="btn-guardar">Guardar Cambios</button>
             
 {% if pacienteid %}
-<p style="color: green; font-weight: bold;">Paciente con ID: {{ pacienteid }}</p>
+<p class="registration-success">Paciente con ID: {{ pacienteid }}</p>
 <a href="file:///C:/Program Files/HuellaApp/HuellaHID.exe {{ pacienteid }}" 
    style="padding:10px; background-color:blue; color:white; border-radius:5px; text-decoration:none;"
    target="_blank">

--- a/tareas/admin/templates/admin/listar_consultas.html
+++ b/tareas/admin/templates/admin/listar_consultas.html
@@ -10,7 +10,7 @@
 {% block contenido %}
 <div class="listado-card">
     <h2>Consultas y Emergencias</h2>
-    <form method="get" class="form-grid" style="margin-bottom:20px;">
+    <form method="get" class="form-grid filter-form">
         <div class="form-field"><input type="text" name="doctor" placeholder="Doctor" value="{{ doctor }}"></div>
         <div class="form-field"><input type="date" name="inicio" value="{{ inicio }}"></div>
         <div class="form-field"><input type="date" name="fin" value="{{ fin }}"></div>

--- a/tareas/admin/templates/admin/listar_pacientes.html
+++ b/tareas/admin/templates/admin/listar_pacientes.html
@@ -14,7 +14,7 @@
         <a href="{% url 'registrar_paciente' %}" class="btn-nuevo">+ Registrar nuevo</a>
         <a href="{% url 'exportar_pacientes' %}" class="btn-nuevo">Exportar CSV</a>
     </div>
-    <form method="get" class="form-grid" style="margin-bottom:20px;">
+    <form method="get" class="form-grid filter-form">
         <div class="form-field"><input type="text" name="q" placeholder="Buscar" value="{{ q }}"></div>
         <div class="form-field">
             <select name="sexo">

--- a/tareas/admin/templates/admin/registrar_paciente.html
+++ b/tareas/admin/templates/admin/registrar_paciente.html
@@ -39,7 +39,7 @@
             
 {% if pacienteid %}
 <div class="form-full" style="margin-top: 15px;">
-  <p style="color: green; font-weight: bold;">
+  <p class="registration-success">
     ✅ Paciente registrado con ID: {{ pacienteid }}
   </p>
 

--- a/tareas/static/admin/css/MenuAdmin.css
+++ b/tareas/static/admin/css/MenuAdmin.css
@@ -11,18 +11,23 @@
 body {
     margin: 0;
     font-family: 'Poppins', sans-serif;
-    background: var(--gradient-bg);
-    background-size: 400% 400%;
-    animation: animado 15s ease infinite;
+    background: url('/static/img/fondo_clinica.jpg') no-repeat center center fixed;
+    background-size: cover;
     display: flex;
-    height: 100vh;
+    min-height: 100vh;
     overflow: hidden;
 }
 
-@keyframes animado {
-    0% {background-position: 0% 50%;}
-    50% {background-position: 100% 50%;}
-    100% {background-position: 0% 50%;}
+body::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(3px);
+    z-index: -1;
 }
 
 /* ------------------ SIDEBAR ------------------ */

--- a/tareas/static/admin/css/listar_personal.css
+++ b/tareas/static/admin/css/listar_personal.css
@@ -92,3 +92,8 @@
     color: #a30000;
     border: 1px solid #ff4d4d;
 }
+
+/* Formulario de filtros en listados */
+.filter-form {
+    margin-bottom: 20px;
+}

--- a/tareas/static/admin/css/registrar_personal.css
+++ b/tareas/static/admin/css/registrar_personal.css
@@ -89,3 +89,9 @@
     text-decoration: underline;
 }
 
+/* Mensaje de registro exitoso */
+.registration-success {
+    color: green;
+    font-weight: bold;
+}
+


### PR DESCRIPTION
## Summary
- add `.filter-form` class for filter forms
- add `.registration-success` message style
- use new classes in admin templates
- use login background across admin

## Testing
- `python3 manage.py check`


------
https://chatgpt.com/codex/tasks/task_b_685a81b4a018832d9def197306d14ca4