### PR TITLE
Apply dark theme with black and blue colors across admin

### DIFF
--- a/tareas/admin/templates/admin/MenuAdmin.html
+++ b/tareas/admin/templates/admin/MenuAdmin.html
@@ -22,6 +22,7 @@
             <li id="inicio"><i class="bi bi-house-fill"></i> Inicio</li>
             <li><i class="bi bi-people-fill"></i> Gestión de Personal</li>
             <li><i class="bi bi-clipboard2-pulse-fill"></i> Servicios Médicos</li>
+            <li><i class="bi bi-layers-fill"></i> Gestión de Especialidades</li>
             <li><i class="bi bi-door-closed-fill"></i> Gestión de Habitaciones</li>
             <li><i class="bi bi-credit-card-2-back-fill"></i> Métodos de Pago</li>
             <li><i class="bi bi-person-lines-fill"></i> Control de Pacientes</li>

--- a/tareas/admin/templates/admin/configuraciones.html
+++ b/tareas/admin/templates/admin/configuraciones.html
@@ -10,7 +10,7 @@
 {% block contenido %}
 <div class="listado-card">
     <h2>Configuraciones Generales</h2>
-    <form method="post" class="form-grid" style="margin-bottom:20px;">
+    <form method="post" class="form-grid filter-form">
         {% csrf_token %}
         <div class="form-field">{{ form.nombre_clinica.label_tag }}{{ form.nombre_clinica }}</div>
         <div class="form-field">{{ form.logo_url.label_tag }}{{ form.logo_url }}</div>

--- a/tareas/admin/templates/admin/editar_paciente.html
+++ b/tareas/admin/templates/admin/editar_paciente.html
@@ -36,7 +36,7 @@
             <button type="submit" class="btn-guardar">Guardar Cambios</button>
             
 {% if pacienteid %}
-<p style="color: green; font-weight: bold;">Paciente con ID: {{ pacienteid }}</p>
+<p class="registration-success">Paciente con ID: {{ pacienteid }}</p>
 <a href="file:///C:/Program Files/HuellaApp/HuellaHID.exe {{ pacienteid }}" 
    style="padding:10px; background-color:blue; color:white; border-radius:5px; text-decoration:none;"
    target="_blank">

--- a/tareas/admin/templates/admin/listar_consultas.html
+++ b/tareas/admin/templates/admin/listar_consultas.html
@@ -10,7 +10,7 @@
 {% block contenido %}
 <div class="listado-card">
     <h2>Consultas y Emergencias</h2>
-    <form method="get" class="form-grid" style="margin-bottom:20px;">
+    <form method="get" class="form-grid filter-form">
         <div class="form-field"><input type="text" name="doctor" placeholder="Doctor" value="{{ doctor }}"></div>
         <div class="form-field"><input type="date" name="inicio" value="{{ inicio }}"></div>
         <div class="form-field"><input type="date" name="fin" value="{{ fin }}"></div>

--- a/tareas/admin/templates/admin/listar_pacientes.html
+++ b/tareas/admin/templates/admin/listar_pacientes.html
@@ -14,7 +14,7 @@
         <a href="{% url 'registrar_paciente' %}" class="btn-nuevo">+ Registrar nuevo</a>
         <a href="{% url 'exportar_pacientes' %}" class="btn-nuevo">Exportar CSV</a>
     </div>
-    <form method="get" class="form-grid" style="margin-bottom:20px;">
+    <form method="get" class="form-grid filter-form">
         <div class="form-field"><input type="text" name="q" placeholder="Buscar" value="{{ q }}"></div>
         <div class="form-field">
             <select name="sexo">

--- a/tareas/admin/templates/admin/registrar_paciente.html
+++ b/tareas/admin/templates/admin/registrar_paciente.html
@@ -39,7 +39,7 @@
             
 {% if pacienteid %}
 <div class="form-full" style="margin-top: 15px;">
-  <p style="color: green; font-weight: bold;">
+  <p class="registration-success">
     ✅ Paciente registrado con ID: {{ pacienteid }}
   </p>
 

--- a/tareas/static/admin/css/MenuAdmin.css
+++ b/tareas/static/admin/css/MenuAdmin.css
@@ -11,18 +11,24 @@
 body {
     margin: 0;
     font-family: 'Poppins', sans-serif;
-    background: var(--gradient-bg);
-    background-size: 400% 400%;
-    animation: animado 15s ease infinite;
+    background: url('/static/img/fondo_clinica.jpg') no-repeat center center fixed;
+    background-size: cover;
+    color: #f0f0f0;
     display: flex;
-    height: 100vh;
+    min-height: 100vh;
     overflow: hidden;
 }
 
-@keyframes animado {
-    0% {background-position: 0% 50%;}
-    50% {background-position: 100% 50%;}
-    100% {background-position: 0% 50%;}
+body::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    backdrop-filter: blur(3px);
+    z-index: -1;
 }
 
 /* ------------------ SIDEBAR ------------------ */
@@ -113,6 +119,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: flex-start;
+    color: #f0f0f0;
 }
 
 /* ------------------ BIENVENIDA ------------------ */
@@ -124,7 +131,7 @@ body {
 
 .welcome p {
     font-size: 1.05rem;
-    color: #333;
+    color: #e0e0e0;
     margin: 5px 0;
 }
 

--- a/tareas/static/admin/css/listar_pacientes.css
+++ b/tareas/static/admin/css/listar_pacientes.css
@@ -4,12 +4,13 @@
     --accent-color: #42a5f5;
 }
 .listado-card {
-    background: white;
+    background: #1c1c1c;
+    color: #f5f5f5;
     border-radius: 16px;
     padding: 40px;
     max-width: 1100px;
     width: 100%;
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.4);
 }
 
 .listado-card h2 {
@@ -55,12 +56,13 @@
 
 .tabla-personal th, .tabla-personal td {
     padding: 12px;
-    border: 1px solid #d0d0d0;
+    border: 1px solid #444;
     text-align: center;
+    color: #fff;
 }
 
 .tabla-personal tbody tr:hover {
-    background-color: #f0f9ff;
+    background-color: #112240;
 }
 
 .activo {

--- a/tareas/static/admin/css/listar_personal.css
+++ b/tareas/static/admin/css/listar_personal.css
@@ -4,12 +4,13 @@
     --accent-color: #42a5f5;
 }
 .listado-card {
-    background: white;
+    background: #1c1c1c;
+    color: #f5f5f5;
     border-radius: 16px;
     padding: 40px;
     max-width: 1100px;
     width: 100%;
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.4);
 }
 
 .listado-card h2 {
@@ -55,12 +56,13 @@
 
 .tabla-personal th, .tabla-personal td {
     padding: 12px;
-    border: 1px solid #d0d0d0;
+    border: 1px solid #444;
     text-align: center;
+    color: #fff;
 }
 
 .tabla-personal tbody tr:hover {
-    background-color: #f0f9ff;
+    background-color: #112240;
 }
 
 .activo {
@@ -91,4 +93,9 @@
     background-color: #ffe6e6;
     color: #a30000;
     border: 1px solid #ff4d4d;
+}
+
+/* Formulario de filtros en listados */
+.filter-form {
+    margin-bottom: 20px;
 }

--- a/tareas/static/admin/css/registrar_paciente.css
+++ b/tareas/static/admin/css/registrar_paciente.css
@@ -4,12 +4,13 @@
     --accent-color: #42a5f5;
 }
 .form-card {
-    background: white;
+    background: #1c1c1c;
+    color: #f5f5f5;
     border-radius: 18px;
     padding: 30px;
     max-width: 1200px;
     width: 100%;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
     overflow-y: auto;
     max-height: calc(100vh - 60px);
 }
@@ -32,7 +33,7 @@
     display: block;
     font-weight: bold;
     margin-bottom: 6px;
-    color: #333;
+    color: #e0e0e0;
     font-size: 14px;
 }
 

--- a/tareas/static/admin/css/registrar_personal.css
+++ b/tareas/static/admin/css/registrar_personal.css
@@ -4,12 +4,13 @@
     --accent-color: #42a5f5;
 }
 .form-card {
-    background: white;
+    background: #1c1c1c;
+    color: #f5f5f5;
     border-radius: 18px;
     padding: 30px;
     max-width: 1200px;
     width: 100%;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
     overflow-y: auto;
     max-height: calc(100vh - 60px);
 }
@@ -32,7 +33,7 @@
     display: block;
     font-weight: bold;
     margin-bottom: 6px;
-    color: #333;
+    color: #e0e0e0;
     font-size: 14px;
 }
 
@@ -87,5 +88,11 @@
 
 .volver:hover {
     text-decoration: underline;
+}
+
+/* Mensaje de registro exitoso */
+.registration-success {
+    color: green;
+    font-weight: bold;
 }
 

--- a/tareas/static/admin/js/MenuAdmin.js
+++ b/tareas/static/admin/js/MenuAdmin.js
@@ -39,6 +39,8 @@ document.addEventListener("DOMContentLoaded", function () {
                 window.location.href = "/admin/listar_personal/";
             } else if (opcion === "Servicios Médicos") {
                 window.location.href = "/admin/servicios/";
+            } else if (opcion === "Gestión de Especialidades") {
+                window.location.href = "/admin/especialidades/";
             } else if (opcion === "Gestión de Habitaciones") {
                 window.location.href = "/admin/habitaciones/";
             } else if ( opcion === "Métodos de Pago") {


### PR DESCRIPTION
## Summary
- use darker overlay and text color in `MenuAdmin.css`
- darken listing cards and tables
- darken form cards for registrations
- add sidebar link for managing specialties

## Testing
- `python3 manage.py check`


------
https://chatgpt.com/codex/tasks/task_b_685a81b4a018832d9def197306d14ca4